### PR TITLE
Missing double-slashes on Zyxel 2nd reference

### DIFF
--- a/known_exploited_vulnerabilities.json
+++ b/known_exploited_vulnerabilities.json
@@ -14,7 +14,7 @@
             "requiredAction": "The impacted product could be end-of-life (EoL) and\/or end-of-service (EoS). Users should discontinue product utilization if a current mitigation is unavailable.",
             "dueDate": "2025-03-04",
             "knownRansomwareCampaignUse": "Unknown",
-            "notes": "https:\/\/www.zyxel.com\/global\/en\/support\/security-advisories\/zyxel-security-advisory-for-command-injection-and-insecure-default-credentials-vulnerabilities-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/www.zyxel.com\/service-provider\/global\/en\/security-advisories\/zyxel-security-advisory-command-injection-insecure-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/\/nvd.nist.gov\/vuln\/detail\/CVE-2024-40891",
+            "notes": "https:\/\/www.zyxel.com\/global\/en\/support\/security-advisories\/zyxel-security-advisory-for-command-injection-and-insecure-default-credentials-vulnerabilities-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/\/www.zyxel.com\/service-provider\/global\/en\/security-advisories\/zyxel-security-advisory-command-injection-insecure-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/\/nvd.nist.gov\/vuln\/detail\/CVE-2024-40891",
             "cwes": [
                 "CWE-78"
             ]
@@ -29,7 +29,7 @@
             "requiredAction": "The impacted product could be end-of-life (EoL) and\/or end-of-service (EoS). Users should discontinue product utilization if a current mitigation is unavailable.",
             "dueDate": "2025-03-04",
             "knownRansomwareCampaignUse": "Unknown",
-            "notes": "https:\/\/www.zyxel.com\/global\/en\/support\/security-advisories\/zyxel-security-advisory-for-command-injection-and-insecure-default-credentials-vulnerabilities-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/www.zyxel.com\/service-provider\/global\/en\/security-advisories\/zyxel-security-advisory-command-injection-insecure-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/\/nvd.nist.gov\/vuln\/detail\/CVE-2024-40890",
+            "notes": "https:\/\/www.zyxel.com\/global\/en\/support\/security-advisories\/zyxel-security-advisory-for-command-injection-and-insecure-default-credentials-vulnerabilities-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/\/ww.zyxel.com\/service-provider\/global\/en\/security-advisories\/zyxel-security-advisory-command-injection-insecure-in-certain-legacy-dsl-cpe-02-04-2025 ; https:\/\/nvd.nist.gov\/vuln\/detail\/CVE-2024-40890",
             "cwes": [
                 "CWE-78"
             ]


### PR DESCRIPTION
## Expected behavior

Links should render normally when parsing the JSON in some HTML-like reader.

## Observed behavior

Typo on the second link in the two Zyxel entries. missing the double slashes. Namely, `https:/` should be `https://`

## Testability

Read it with your eyeballs, or in an HTML-aware JSON parser for the vuln data. Namely, the entries for CVE-2024-40890 and CVE-2024-40891.
