### PR TITLE
Remove errant quote

### DIFF
--- a/known_exploited_vulnerabilities.json
+++ b/known_exploited_vulnerabilities.json
@@ -14,7 +14,7 @@
             "requiredAction": "Apply mitigations per vendor instructions or discontinue use of the product if mitigations are unavailable.",
             "dueDate": "2025-03-06",
             "knownRansomwareCampaignUse": "Unknown",
-            "notes": "\"https:\/\/simple-help.com\/kb---security-vulnerabilities-01-2025 ; https:\/\/nvd.nist.gov\/vuln\/detail\/CVE-2024-57727",
+            "notes": "https:\/\/simple-help.com\/kb---security-vulnerabilities-01-2025 ; https:\/\/nvd.nist.gov\/vuln\/detail\/CVE-2024-57727",
             "cwes": [
                 "CWE-22"
             ]


### PR DESCRIPTION
There's an errant quote in the notes for CVE-2024-57727 for SimpleHelp. It's borking up some rendering.
